### PR TITLE
Fixes #8 - Fix support for standard promises

### DIFF
--- a/async-fragment-tag.js
+++ b/async-fragment-tag.js
@@ -17,8 +17,7 @@ function promiseToCallback(promise, callback, thisObj) {
             },
             function(err) {
                 callback(err);
-            })
-            .done();
+            });
     }
 
     return promise;

--- a/async-fragment-tag.js
+++ b/async-fragment-tag.js
@@ -18,6 +18,9 @@ function promiseToCallback(promise, callback, thisObj) {
             function(err) {
                 callback(err);
             });
+        if (finalPromise.done) {
+            finalPromise.done();
+        }
     }
 
     return promise;

--- a/async-fragment-tag.js
+++ b/async-fragment-tag.js
@@ -11,7 +11,7 @@ function isPromise(o) {
 
 function promiseToCallback(promise, callback, thisObj) {
     if (callback) {
-        promise.then(
+        var finalPromise = promise.then(
             function(data) {
                 callback(null, data);
             },


### PR DESCRIPTION
Promises were breaking for me using `es6-promise` and `rsvp`. I suspect it is because "promise.done... has not been standardised" (https://www.promisejs.org/)

Without the `.done()` it works now!