### PR TITLE
Data provider as promise - reject handler fix

### DIFF
--- a/async-fragment-tag.js
+++ b/async-fragment-tag.js
@@ -14,7 +14,7 @@ function promiseToCallback(promise, callback, thisObj) {
         var finalPromise = promise.then(
             function(data) {
                 callback(null, data);
-            },
+            }).fail(
             function(err) {
                 callback(err);
             });


### PR DESCRIPTION
Moving the onReject handler from .then() to .fail() chain to allow any runtime exception in the async fragment rendering to trigger the `async-fragment-error` rendering.